### PR TITLE
Add support for Multi-Channel OpenEXR on tk-flame-export

### DIFF
--- a/env/includes/app_locations.yml
+++ b/env/includes/app_locations.yml
@@ -171,7 +171,7 @@ apps.tk-nuke-writenode.location:
 apps.tk-flame-export.location:
   name: tk-flame-export
   type: app_store
-  version: v1.7.9
+  version: v1.7.10
 
 # flame review
 apps.tk-flame-review.location:

--- a/env/includes/settings/tk-flame-export.yml
+++ b/env/includes/settings/tk-flame-export.yml
@@ -42,4 +42,16 @@ settings.tk-flame-export:
     start_frame: 100
     frame_handles: 10
     cut_type: ""
+  - template: flame_shot_render_exr
+    publish_type: Flame Render
+    name: 16 bit OpenEXR - Multi-Channel
+    upload_quicktime: true
+    quicktime_publish_type: Flame Quicktime
+    quicktime_template:
+    batch_quicktime_template:
+    batch_render_template: flame_shot_comp_exr
+    start_frame: 100
+    frame_handles: 10
+    cut_type: ''
+    min_version: "2019.0"
   location: "@apps.tk-flame-export.location"


### PR DESCRIPTION
This PR integrate the changes for https://github.com/shotgunsoftware/tk-flame-export/pull/17

Someone running Flame 2019.0+ will now have a new preset when using tk-flame-export