### PR TITLE
Add a new {flame.frame} sequence token and use it in flame templates

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -67,6 +67,10 @@ keys:
     SEQ:
         type: sequence
         format_spec: "04"
+    timecode:
+        type: sequence
+        format_spec: "08"
+
     eye:
         type: str
 
@@ -186,13 +190,13 @@ paths:
     flame_shot_batch:
         definition: 'sequences/{Sequence}/{Shot}/finishing/batch/{Shot}.v{version}.batch'
     flame_shot_render_dpx:
-        definition: 'sequences/{Sequence}/{Shot}/finishing/renders/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{SEQ}.dpx'
+        definition: 'sequences/{Sequence}/{Shot}/finishing/renders/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{timecode}.dpx'
     flame_shot_render_exr:
-        definition: 'sequences/{Sequence}/{Shot}/finishing/renders/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{SEQ}.exr'
+        definition: 'sequences/{Sequence}/{Shot}/finishing/renders/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{timecode}.exr'
     flame_shot_comp_dpx:
-        definition: 'sequences/{Sequence}/{Shot}/finishing/comp/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{SEQ}.dpx'
+        definition: 'sequences/{Sequence}/{Shot}/finishing/comp/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{timecode}.dpx'
     flame_shot_comp_exr:
-        definition: 'sequences/{Sequence}/{Shot}/finishing/comp/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{SEQ}.exr'
+        definition: 'sequences/{Sequence}/{Shot}/finishing/comp/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{timecode}.exr'
 
     #
     # Photoshop

--- a/core/templates.yml
+++ b/core/templates.yml
@@ -67,7 +67,9 @@ keys:
     SEQ:
         type: sequence
         format_spec: "04"
-    timecode:
+
+    # Represents a frame sequence exported from Flame
+    flame.frame:
         type: sequence
         format_spec: "08"
 
@@ -190,13 +192,13 @@ paths:
     flame_shot_batch:
         definition: 'sequences/{Sequence}/{Shot}/finishing/batch/{Shot}.v{version}.batch'
     flame_shot_render_dpx:
-        definition: 'sequences/{Sequence}/{Shot}/finishing/renders/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{timecode}.dpx'
+        definition: 'sequences/{Sequence}/{Shot}/finishing/renders/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{flame.frame}.dpx'
     flame_shot_render_exr:
-        definition: 'sequences/{Sequence}/{Shot}/finishing/renders/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{timecode}.exr'
+        definition: 'sequences/{Sequence}/{Shot}/finishing/renders/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{flame.frame}.exr'
     flame_shot_comp_dpx:
-        definition: 'sequences/{Sequence}/{Shot}/finishing/comp/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{timecode}.dpx'
+        definition: 'sequences/{Sequence}/{Shot}/finishing/comp/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{flame.frame}.dpx'
     flame_shot_comp_exr:
-        definition: 'sequences/{Sequence}/{Shot}/finishing/comp/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{timecode}.exr'
+        definition: 'sequences/{Sequence}/{Shot}/finishing/comp/{segment_name}_v{version}/{Shot}_{segment_name}_v{version}.{flame.frame}.exr'
 
     #
     # Photoshop

--- a/env/includes/settings/tk-flame-export.yml
+++ b/env/includes/settings/tk-flame-export.yml
@@ -30,6 +30,7 @@ settings.tk-flame-export:
     batch_render_template: flame_shot_comp_dpx
     start_frame: 100
     frame_handles: 10
+    use_timecode_as_frame_number: True
     cut_type: ""
   - template: flame_shot_render_exr
     publish_type: Flame Render
@@ -41,6 +42,7 @@ settings.tk-flame-export:
     batch_render_template: flame_shot_comp_exr
     start_frame: 100
     frame_handles: 10
+    use_timecode_as_frame_number: True
     cut_type: ""
   - template: flame_shot_render_exr
     publish_type: Flame Render
@@ -52,6 +54,7 @@ settings.tk-flame-export:
     batch_render_template: flame_shot_comp_exr
     start_frame: 100
     frame_handles: 10
+    use_timecode_as_frame_number: True
     cut_type: ''
     min_version: "2019.0"
   location: "@apps.tk-flame-export.location"


### PR DESCRIPTION
JIRA: SMOK-49006 SMOK-48846

In workflow with Flame, it is easier to work with file sequence numbered using
the timecode as the frame number. Add a template token to specify that that is
padded with 8 zeros instead of just 4.