### PR TITLE
Propose new default filter_by for name

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -39,7 +39,7 @@ keys:
         type: str
     name:
         type: str
-        filter_by: alphanumeric
+        filter_by: '^[a-zA-Z0-9_-]+$'
     iteration:
         type: int
     version:


### PR DESCRIPTION
I would like to propose this modification to make the default filter allow the dash and underscore characters but disallow the other special characters.

Not sure how this affects unicode and other language support.