### PR TITLE
SG-9477 adds launchfolder app to PublishedFile environment

### DIFF
--- a/core/hooks/pick_environment.py
+++ b/core/hooks/pick_environment.py
@@ -23,8 +23,10 @@ class PickEnvironment(Hook):
         and project, and switches to these based on entity type.
         """
         if context.source_entity:
-            if context.source_entity["type"] in ["Version", "PublishedFile"]:
-                return "publishedfile_version"
+            if context.source_entity["type"] == "Version":
+                return "version"
+            elif context.source_entity["type"] == "PublishedFile":
+                return "publishedfile"
 
         if context.project is None:
             # Our context is completely empty. We're going into the site context.

--- a/env/includes/settings/tk-shotgun.yml
+++ b/env/includes/settings/tk-shotgun.yml
@@ -58,10 +58,17 @@ settings.tk-shotgun.project:
   location: "@engines.tk-shotgun.location"
 
 # publishedfile_version
-settings.tk-shotgun.publishedfile_version:
+settings.tk-shotgun.version:
   apps:
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-shotgun-launchpublish: "@settings.tk-shotgun-launchpublish"
+  location: "@engines.tk-shotgun.location"
+
+settings.tk-shotgun.publishedfile:
+  apps:
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-shotgun-launchpublish: "@settings.tk-shotgun-launchpublish"
+    tk-shotgun-launchfolder: "@settings.tk-shotgun-launchfolder"
   location: "@engines.tk-shotgun.location"
 
 # sequence

--- a/env/publishedfile.yml
+++ b/env/publishedfile.yml
@@ -24,7 +24,7 @@ includes:
 # configuration for all engines to load in a publishedfile or version context
 
 engines:
-  tk-shotgun: "@settings.tk-shotgun.publishedfile_version"
+  tk-shotgun: "@settings.tk-shotgun.publishedfile"
 
 ################################################################################
 # reference all of the common frameworks

--- a/env/publishedfile.yml
+++ b/env/publishedfile.yml
@@ -21,7 +21,7 @@ includes:
 - ./includes/settings/tk-shotgun.yml
 
 ################################################################################
-# configuration for all engines to load in a publishedfile or version context
+# configuration for all engines to load in a publishedfile context
 
 engines:
   tk-shotgun: "@settings.tk-shotgun.publishedfile"

--- a/env/publishedfile.yml
+++ b/env/publishedfile.yml
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 #
 
-description: Apps and engines loaded when a PublishedFile or Version is loaded.
+description: Apps and engines loaded when a PublishedFile is loaded.
   By default, the only engine defined here is tk-shotgun. This configuration
   provides the apps that are necessary to display menu actions in the Shotgun
   web application by way of Toolkit"s browser integration.

--- a/env/publishedfile.yml
+++ b/env/publishedfile.yml
@@ -12,7 +12,7 @@
 description: Apps and engines loaded when a PublishedFile is loaded.
   By default, the only engine defined here is tk-shotgun. This configuration
   provides the apps that are necessary to display menu actions in the Shotgun
-  web application by way of Toolkit"s browser integration.
+  web application by way of Toolkit's browser integration.
 
 ################################################################################
 

--- a/env/version.yml
+++ b/env/version.yml
@@ -1,0 +1,32 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: Apps and engines loaded when a PublishedFile or Version is loaded.
+  By default, the only engine defined here is tk-shotgun. This configuration
+  provides the apps that are necessary to display menu actions in the Shotgun
+  web application by way of Toolkit"s browser integration.
+
+################################################################################
+
+includes:
+- ./includes/frameworks.yml
+- ./includes/settings/tk-shotgun.yml
+
+################################################################################
+# configuration for all engines to load in a publishedfile or version context
+
+engines:
+  tk-shotgun: "@settings.tk-shotgun.version"
+
+################################################################################
+# reference all of the common frameworks
+
+frameworks: "@frameworks"

--- a/env/version.yml
+++ b/env/version.yml
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 #
 
-description: Apps and engines loaded when a PublishedFile or Version is loaded.
+description: Apps and engines loaded when a Version is loaded.
   By default, the only engine defined here is tk-shotgun. This configuration
   provides the apps that are necessary to display menu actions in the Shotgun
   web application by way of Toolkit"s browser integration.

--- a/env/version.yml
+++ b/env/version.yml
@@ -21,7 +21,7 @@ includes:
 - ./includes/settings/tk-shotgun.yml
 
 ################################################################################
-# configuration for all engines to load in a publishedfile or version context
+# configuration for all engines to load in a version context
 
 engines:
   tk-shotgun: "@settings.tk-shotgun.version"

--- a/env/version.yml
+++ b/env/version.yml
@@ -12,7 +12,7 @@
 description: Apps and engines loaded when a Version is loaded.
   By default, the only engine defined here is tk-shotgun. This configuration
   provides the apps that are necessary to display menu actions in the Shotgun
-  web application by way of Toolkit"s browser integration.
+  web application by way of Toolkit's browser integration.
 
 ################################################################################
 


### PR DESCRIPTION
This pull request adds the `tk-shotgun-launchfolder` app to the PublishedFile environment, due to the app's recent support for the entity type.

In order to add it to the `PublishedFile` entity, and not the `Version` entity, I have had to separate the two environments.