### PR TITLE
Update to tk-flame v1.15.2

### DIFF
--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -41,7 +41,7 @@ engines.tk-desktop2.location:
 engines.tk-flame.location:
   type: app_store
   name: tk-flame
-  version: v1.15.1
+  version: v1.15.2
 
 # Houdini
 engines.tk-houdini.location:


### PR DESCRIPTION
JIRA: SMOK-51684
Shotgun can submit backburner jobs with a job name that is too long, error on submission