### PR TITLE
SG-14434: Switch to the new tk-3dsmax engine.

### DIFF
--- a/core/schema/project/assets/asset_type/asset/step/publish/3dsmax.yml
+++ b/core/schema/project/assets/asset_type/asset/step/publish/3dsmax.yml
@@ -12,5 +12,5 @@
 type: "static"
 
 # defer creation and only create this folder when 3dsmax starts
-defer_creation: ["tk-3dsmax", "tk-3dsmaxplus"]
+defer_creation: ["tk-3dsmax"]
 

--- a/core/schema/project/assets/asset_type/asset/step/work/3dsmax.yml
+++ b/core/schema/project/assets/asset_type/asset/step/work/3dsmax.yml
@@ -12,5 +12,5 @@
 type: "static"
 
 # defer creation and only create this folder when 3dsmax starts
-defer_creation: ["tk-3dsmax", "tk-3dsmaxplus"]
+defer_creation: ["tk-3dsmax"]
 

--- a/core/schema/project/sequences/sequence/shot/step/publish/3dsmax.yml
+++ b/core/schema/project/sequences/sequence/shot/step/publish/3dsmax.yml
@@ -12,5 +12,5 @@
 type: "static"
 
 # defer creation and only create this folder when 3dsmax starts
-defer_creation: ["tk-3dsmax", "tk-3dsmaxplus"]
+defer_creation: ["tk-3dsmax"]
 

--- a/core/schema/project/sequences/sequence/shot/step/work/3dsmax.yml
+++ b/core/schema/project/sequences/sequence/shot/step/work/3dsmax.yml
@@ -12,5 +12,5 @@
 type: "static"
 
 # defer creation and only create this folder when 3dsmax starts
-defer_creation: ["tk-3dsmax", "tk-3dsmaxplus"]
+defer_creation: ["tk-3dsmax"]
 

--- a/env/asset.yml
+++ b/env/asset.yml
@@ -22,7 +22,7 @@ description: Apps and engines loaded when an Asset is loaded. Since std VFX
 
 includes:
 - ./includes/frameworks.yml
-- ./includes/settings/tk-3dsmaxplus.yml
+- ./includes/settings/tk-3dsmax.yml
 - ./includes/settings/tk-houdini.yml
 - ./includes/settings/tk-mari.yml
 - ./includes/settings/tk-maya.yml
@@ -37,7 +37,7 @@ includes:
 # configuration for all engines to load in an asset context
 
 engines:
-  tk-3dsmaxplus: "@settings.tk-3dsmaxplus.asset"
+  tk-3dsmax: "@settings.tk-3dsmax.asset"
   tk-houdini: "@settings.tk-houdini.asset"
   tk-mari: "@settings.tk-mari.asset"
   tk-maya: "@settings.tk-maya.asset"

--- a/env/asset_step.yml
+++ b/env/asset_step.yml
@@ -16,7 +16,7 @@ description: Apps and Engines related to Asset based work.
 includes:
 - ./includes/frameworks.yml
 - ./includes/settings/tk-desktop2.yml
-- ./includes/settings/tk-3dsmaxplus.yml
+- ./includes/settings/tk-3dsmax.yml
 - ./includes/settings/tk-houdini.yml
 - ./includes/settings/tk-mari.yml
 - ./includes/settings/tk-maya.yml
@@ -32,7 +32,7 @@ includes:
 
 engines:
   tk-desktop2: "@settings.tk-desktop2.all"
-  tk-3dsmaxplus: "@settings.tk-3dsmaxplus.asset_step"
+  tk-3dsmax: "@settings.tk-3dsmax.asset_step"
   tk-houdini: "@settings.tk-houdini.asset_step"
   tk-mari: "@settings.tk-mari.asset_step"
   tk-maya: "@settings.tk-maya.asset_step"

--- a/env/includes/app_locations.yml
+++ b/env/includes/app_locations.yml
@@ -45,9 +45,8 @@ apps.tk-multi-launchapp.location:
 
 # loader2
 apps.tk-multi-loader2.location:
-  type: app_store
-  name: tk-multi-loader2
-  version: v1.19.4
+  type: dev
+  path: "$DEV_ROOT/gitlocal/tk-multi-loader2"
 
 # publish2
 apps.tk-multi-publish2.location:
@@ -87,9 +86,8 @@ apps.tk-multi-shotgunpanel.location:
 
 # snapshot
 apps.tk-multi-snapshot.location:
-  type: app_store
-  name: tk-multi-snapshot
-  version: v0.7.4
+  type: dev
+  path: "$DEV_ROOT/gitlocal/tk-multi-snapshot"
 
 # workfiles (required for Mari)
 apps.tk-multi-workfiles.location:
@@ -99,9 +97,8 @@ apps.tk-multi-workfiles.location:
 
 # workfiles2
 apps.tk-multi-workfiles2.location:
-  type: app_store
-  name: tk-multi-workfiles2
-  version: v0.11.14
+  type: dev
+  path: "$DEV_ROOT/gitlocal/tk-multi-workfiles2"
 
 # dev utils
 apps.tk-multi-devutils.location:

--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -16,7 +16,7 @@
 # 3dsMax
 engines.tk-3dsmax.location:
   type: dev
-  path: "$DEV_ROOT/tk-3dsmax"
+  path: "$DEV_ROOT/gitlocal/tk-3dsmax"
 
 # After Effects
 engines.tk-aftereffects.location:

--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -14,10 +14,9 @@
 ################################################################################
 
 # 3dsMax
-engines.tk-3dsmaxplus.location:
-  type: app_store
-  name: tk-3dsmaxplus
-  version: v0.5.8
+engines.tk-3dsmax.location:
+  type: dev
+  path: "$DEV_ROOT/tk-3dsmax"
 
 # After Effects
 engines.tk-aftereffects.location:

--- a/env/includes/settings/tk-3dsmax.yml
+++ b/env/includes/settings/tk-3dsmax.yml
@@ -24,7 +24,7 @@ includes:
 ################################################################################
 
 # asset
-settings.tk-3dsmaxplus.asset:
+settings.tk-3dsmax.asset:
   apps:
     tk-multi-about:
       location: "@apps.tk-multi-about.location"
@@ -35,10 +35,10 @@ settings.tk-3dsmaxplus.asset:
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
-  location: "@engines.tk-3dsmaxplus.location"
+  location: "@engines.tk-3dsmax.location"
 
 # asset_step
-settings.tk-3dsmaxplus.asset_step:
+settings.tk-3dsmax.asset_step:
   apps:
     tk-multi-about:
       location: "@apps.tk-multi-about.location"
@@ -50,10 +50,10 @@ settings.tk-3dsmaxplus.asset_step:
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.3dsmax"
     tk-multi-snapshot: "@settings.tk-multi-snapshot.3dsmax.asset_step"
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.3dsmax.asset_step"
-  location: "@engines.tk-3dsmaxplus.location"
+  location: "@engines.tk-3dsmax.location"
 
 # project
-settings.tk-3dsmaxplus.project:
+settings.tk-3dsmax.project:
   apps:
     tk-multi-about:
       location: "@apps.tk-multi-about.location"
@@ -64,10 +64,10 @@ settings.tk-3dsmaxplus.project:
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
-  location: "@engines.tk-3dsmaxplus.location"
+  location: "@engines.tk-3dsmax.location"
 
 # sequence
-settings.tk-3dsmaxplus.sequence:
+settings.tk-3dsmax.sequence:
   apps:
     tk-multi-about:
       location: "@apps.tk-multi-about.location"
@@ -78,10 +78,10 @@ settings.tk-3dsmaxplus.sequence:
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
-  location: "@engines.tk-3dsmaxplus.location"
+  location: "@engines.tk-3dsmax.location"
 
 # shot
-settings.tk-3dsmaxplus.shot:
+settings.tk-3dsmax.shot:
   apps:
     tk-multi-about:
       location: "@apps.tk-multi-about.location"
@@ -92,10 +92,10 @@ settings.tk-3dsmaxplus.shot:
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
-  location: "@engines.tk-3dsmaxplus.location"
+  location: "@engines.tk-3dsmax.location"
 
 # shot_step
-settings.tk-3dsmaxplus.shot_step:
+settings.tk-3dsmax.shot_step:
   apps:
     tk-multi-about:
       location: "@apps.tk-multi-about.location"
@@ -109,4 +109,4 @@ settings.tk-3dsmaxplus.shot_step:
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel.3dsmax"
     tk-multi-snapshot: "@settings.tk-multi-snapshot.3dsmax.shot_step"
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.3dsmax.shot_step"
-  location: "@engines.tk-3dsmaxplus.location"
+  location: "@engines.tk-3dsmax.location"

--- a/env/includes/settings/tk-3dsmax.yml
+++ b/env/includes/settings/tk-3dsmax.yml
@@ -32,7 +32,7 @@ settings.tk-3dsmax.asset:
       location: "@apps.tk-multi-pythonconsole.location"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
+    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.3dsmax"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
   location: "@engines.tk-3dsmax.location"
@@ -61,7 +61,7 @@ settings.tk-3dsmax.project:
       location: "@apps.tk-multi-pythonconsole.location"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
+    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.3dsmax"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
   location: "@engines.tk-3dsmax.location"
@@ -75,7 +75,7 @@ settings.tk-3dsmax.sequence:
       location: "@apps.tk-multi-pythonconsole.location"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
+    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.3dsmax"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
   location: "@engines.tk-3dsmax.location"
@@ -89,7 +89,7 @@ settings.tk-3dsmax.shot:
       location: "@apps.tk-multi-pythonconsole.location"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
-    tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
+    tk-multi-workfiles2: "@settings.tk-multi-workfiles2.3dsmax"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
   location: "@engines.tk-3dsmax.location"

--- a/env/includes/settings/tk-multi-loader2.yml
+++ b/env/includes/settings/tk-multi-loader2.yml
@@ -17,6 +17,7 @@ includes:
 
 # 3dsmax
 settings.tk-multi-loader2.3dsmax:
+  actions_hook: "{engine}/tk-multi-loader2/basic/scene_actions.py"
   action_mappings:
     3dsmax Scene: [import, reference]
     Alembic Cache: [import]

--- a/env/includes/settings/tk-multi-shotgunpanel.yml
+++ b/env/includes/settings/tk-multi-shotgunpanel.yml
@@ -51,6 +51,7 @@ settings.tk-multi-shotgunpanel.3dsmax:
     Version:
     - actions: [quicktime_clipboard, sequence_clipboard, add_to_playlist]
       filters: {}
+  actions_hook: "{engine}/tk-multi-shotgunpanel/basic/scene_actions.py"
   location: "@apps.tk-multi-shotgunpanel.location"
 
 # houdini

--- a/env/includes/settings/tk-multi-snapshot.yml
+++ b/env/includes/settings/tk-multi-snapshot.yml
@@ -21,11 +21,13 @@ settings.tk-multi-snapshot.3dsmax.asset_step:
   template_snapshot: max_asset_snapshot
   template_work: max_asset_work
   location: "@apps.tk-multi-snapshot.location"
+  hook_scene_operation: "{engine}/tk-multi-snapshot/basic/scene_operation.py"
 
 settings.tk-multi-snapshot.3dsmax.shot_step:
   template_snapshot: max_shot_snapshot
   template_work: max_shot_work
   location: "@apps.tk-multi-snapshot.location"
+  hook_scene_operation: "{engine}/tk-multi-snapshot/basic/scene_operation.py"
 
 
 ################################################################################

--- a/env/includes/settings/tk-multi-workfiles2.yml
+++ b/env/includes/settings/tk-multi-workfiles2.yml
@@ -79,6 +79,29 @@ settings.tk-multi-workfiles2.launch_at_startup:
 
 # ---- 3dsmax
 
+settings.tk-multi-workfiles2.3dsmax:
+  entities:
+  - caption: Assets
+    entity_type: Asset
+    hierarchy: [sg_asset_type, code]
+    filters:
+    sub_hierarchy:
+      entity_type: Task
+      filters:
+      link_field: entity
+      hierarchy: [step]
+  - caption: Shots
+    entity_type: Shot
+    filters:
+    hierarchy: [sg_sequence, code]
+    sub_hierarchy:
+      entity_type: Task
+      filters:
+      link_field: entity
+      hierarchy: [step]
+  hook_scene_operation: "{engine}/tk-multi-workfiles2/basic/scene_operation.py"
+  location: "@apps.tk-multi-workfiles2.location"
+
 settings.tk-multi-workfiles2.3dsmax.asset_step:
   template_publish: max_asset_publish
   template_publish_area: asset_publish_area_max
@@ -103,6 +126,7 @@ settings.tk-multi-workfiles2.3dsmax.asset_step:
       filters:
       link_field: entity
       hierarchy: [step]
+  hook_scene_operation: "{engine}/tk-multi-workfiles2/basic/scene_operation.py"
   location: "@apps.tk-multi-workfiles2.location"
 
 settings.tk-multi-workfiles2.3dsmax.shot_step:
@@ -129,6 +153,7 @@ settings.tk-multi-workfiles2.3dsmax.shot_step:
       filters:
       link_field: entity
       hierarchy: [step]
+  hook_scene_operation: "{engine}/tk-multi-workfiles2/basic/scene_operation.py"
   location: "@apps.tk-multi-workfiles2.location"
 
 ################################################################################

--- a/env/project.yml
+++ b/env/project.yml
@@ -15,7 +15,7 @@ description: Apps and Engines when launching with a project only context.
 
 includes:
 - ./includes/frameworks.yml
-- ./includes/settings/tk-3dsmaxplus.yml
+- ./includes/settings/tk-3dsmax.yml
 - ./includes/settings/tk-desktop.yml
 - ./includes/settings/tk-flame.yml
 - ./includes/settings/tk-houdini.yml
@@ -32,7 +32,7 @@ includes:
 # configuration for all engines to load in a project context
 
 engines:
-  tk-3dsmaxplus: "@settings.tk-3dsmaxplus.project"
+  tk-3dsmax: "@settings.tk-3dsmax.project"
   tk-desktop: "@settings.tk-desktop.project"
   tk-flame: "@settings.tk-flame.project"
   tk-hiero: "@settings.tk-nuke.hiero.project"

--- a/env/sequence.yml
+++ b/env/sequence.yml
@@ -22,7 +22,7 @@ description: Apps and engines loaded when a Sequence is loaded. Since std VFX
 
 includes:
 - ./includes/frameworks.yml
-- ./includes/settings/tk-3dsmaxplus.yml
+- ./includes/settings/tk-3dsmax.yml
 - ./includes/settings/tk-houdini.yml
 - ./includes/settings/tk-maya.yml
 - ./includes/settings/tk-motionbuilder.yml
@@ -34,7 +34,7 @@ includes:
 # configuration for all engines to load in a sequence context
 
 engines:
-  tk-3dsmaxplus: "@settings.tk-3dsmaxplus.sequence"
+  tk-3dsmax: "@settings.tk-3dsmax.sequence"
   tk-houdini: "@settings.tk-houdini.sequence"
   tk-maya: "@settings.tk-maya.sequence"
   tk-motionbuilder: "@settings.tk-motionbuilder.sequence"

--- a/env/shot.yml
+++ b/env/shot.yml
@@ -22,7 +22,7 @@ description: Apps and engines loaded when a Shot is loaded. Since std VFX config
 
 includes:
 - ./includes/frameworks.yml
-- ./includes/settings/tk-3dsmaxplus.yml
+- ./includes/settings/tk-3dsmax.yml
 - ./includes/settings/tk-flame.yml
 - ./includes/settings/tk-houdini.yml
 - ./includes/settings/tk-maya.yml
@@ -37,7 +37,7 @@ includes:
 # configuration for all engines to load in a shot context
 
 engines:
-  tk-3dsmaxplus: "@settings.tk-3dsmaxplus.shot"
+  tk-3dsmax: "@settings.tk-3dsmax.shot"
   tk-flame: "@settings.tk-flame.shot"
   tk-houdini: "@settings.tk-houdini.shot"
   tk-maya: "@settings.tk-maya.shot"

--- a/env/shot_step.yml
+++ b/env/shot_step.yml
@@ -16,7 +16,7 @@ description: Apps and Engines related to Shot based work.
 includes:
 - ./includes/frameworks.yml
 - ./includes/settings/tk-desktop2.yml
-- ./includes/settings/tk-3dsmaxplus.yml
+- ./includes/settings/tk-3dsmax.yml
 - ./includes/settings/tk-houdini.yml
 - ./includes/settings/tk-maya.yml
 - ./includes/settings/tk-motionbuilder.yml
@@ -32,7 +32,7 @@ includes:
 engines:
   # referencing the DCC-specific shot_step environments included above
   tk-desktop2: "@settings.tk-desktop2.all"
-  tk-3dsmaxplus: "@settings.tk-3dsmaxplus.shot_step"
+  tk-3dsmax: "@settings.tk-3dsmax.shot_step"
   tk-houdini: "@settings.tk-houdini.shot_step"
   tk-maya: "@settings.tk-maya.shot_step"
   tk-motionbuilder: "@settings.tk-motionbuilder.shot_step"


### PR DESCRIPTION
This updates the configuration to use the new `tk-3dsmax` engine. It updates the descriptors of the engine and of the Toolkit applications used in `3dsMax`. It also updates the locations of the hooks.

See this [page](http://developer.shotgunsoftware.com/tk-3dsmax/migration.html) for more details.