### PR TITLE
Removed tk-framework-locking reference for tk-vred in project context

### DIFF
--- a/env/includes/settings/tk-vred.yml
+++ b/env/includes/settings/tk-vred.yml
@@ -62,5 +62,4 @@ settings.tk-vred.project:
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.vred"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
-  file_usage_hook: "{tk-framework-locking_v0.x.x}/apps/vred_file_usage.py"
   location: "@engines.tk-vred.location"


### PR DESCRIPTION
The reference to the framework `tk-framework-locking` is never used and should be removed.