### PR TITLE
Remove VRED geometry publish hook and template

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -675,10 +675,6 @@ paths:
     vred_asset_publish:
         definition: '@asset_root/publish/vred/{name}.v{version}.vpb'
 
-    # define the location of VRED geometry published files
-    vred_asset_geometry_publish:
-        definition: '@asset_root/publish/vred/geometry/{name}.v{version}.osb'
-
     # define the location of the WIP render images
     vred_asset_render_work:
         definition: '@asset_root/work/images/{name}/v{version}/{Asset}_{name}_v{version}[-{vred.render_pass}].{vred.render_extension}'

--- a/env/includes/settings/tk-multi-publish2.yml
+++ b/env/includes/settings/tk-multi-publish2.yml
@@ -540,10 +540,6 @@ settings.tk-multi-publish2.vred.asset_step:
      hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
      settings:
        Publish Template: vred_asset_publish
-   - name: Publish to Shotgun
-     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session_geometry.py"
-     settings:
-       Publish Template: vred_asset_geometry_publish
    - name: Publish Rendering to Shotgun
      hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_rendering.py"
      settings:


### PR DESCRIPTION
Geometry plugin for VRED has been removed, so we no longer need the corresponding template and hook in the config.