### PR TITLE
Add settings for template file to open on creating a new file for Alias

### DIFF
--- a/core/schema/work_area/assets/template_files.yml
+++ b/core/schema/work_area/assets/template_files.yml
@@ -1,0 +1,1 @@
+type: "static"

--- a/core/schema/work_area/assets/template_files/alias.yml
+++ b/core/schema/work_area/assets/template_files/alias.yml
@@ -1,0 +1,1 @@
+type: "static"

--- a/core/templates.yml
+++ b/core/templates.yml
@@ -655,6 +655,11 @@ paths:
         definition: '@asset_root/publish/alias/{project_name}_{Asset}_{Step}_{name}.v{version}.wire'
         root_name: 'publish'
 
+    # define template files to import on creating new file
+    alias_new_file_template:
+        definition: "assets/template_files/alias/{sg_asset_type}_{Step}_new_file.wire"
+
+
     # Alias translations
 
     # The location of the reference created on the fly by Alias when importing a file as ref
@@ -740,6 +745,3 @@ strings:
 
     # define how new Mari projects should be named
     mari_asset_project_name: "{mari.project_name} - Asset {asset_name}, {task_name}"
-
-    # define template files to import on creating new file
-    alias_new_file_template_path: "data/templates/new_file/{Step}/{sg_asset_type}/new_file_template.wire"

--- a/core/templates.yml
+++ b/core/templates.yml
@@ -740,3 +740,6 @@ strings:
 
     # define how new Mari projects should be named
     mari_asset_project_name: "{mari.project_name} - Asset {asset_name}, {task_name}"
+
+    # define template files to import on creating new file
+    alias_new_file_template_path: "data/templates/new_file/{Step}/{sg_asset_type}/new_file_template.wire"

--- a/env/includes/settings/tk-alias.yml
+++ b/env/includes/settings/tk-alias.yml
@@ -57,6 +57,9 @@ settings.tk-alias.asset_step:
   - {app_instance: tk-multi-snapshot, name: Snapshot...}
   - {app_instance: tk-multi-workfiles2, name: File Save...}
   - {app_instance: tk-multi-publish2, name: Publish...}
+  new_file_template:
+    Modeling:
+      Exterior: "data/templates/new_file/Modeling/Exterior/new_file_template.wire"
   location: "@engines.tk-alias.location"
 
 # project
@@ -70,4 +73,7 @@ settings.tk-alias.project:
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.alias"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
+  new_file_template:
+    Modeling:
+      Exterior: "data/templates/new_file/Modeling/new_file_template.wire"
   location: "@engines.tk-alias.location"

--- a/env/includes/settings/tk-alias.yml
+++ b/env/includes/settings/tk-alias.yml
@@ -57,9 +57,7 @@ settings.tk-alias.asset_step:
   - {app_instance: tk-multi-snapshot, name: Snapshot...}
   - {app_instance: tk-multi-workfiles2, name: File Save...}
   - {app_instance: tk-multi-publish2, name: Publish...}
-  new_file_template:
-    Modeling:
-      Exterior: "data/templates/new_file/Modeling/Exterior/new_file_template.wire"
+  new_file_template: alias_new_file_template_path
   location: "@engines.tk-alias.location"
 
 # project
@@ -73,7 +71,5 @@ settings.tk-alias.project:
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.alias"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
-  new_file_template:
-    Modeling:
-      Exterior: "data/templates/new_file/Modeling/new_file_template.wire"
+  new_file_template: alias_new_file_template_path
   location: "@engines.tk-alias.location"

--- a/env/includes/settings/tk-alias.yml
+++ b/env/includes/settings/tk-alias.yml
@@ -57,7 +57,7 @@ settings.tk-alias.asset_step:
   - {app_instance: tk-multi-snapshot, name: Snapshot...}
   - {app_instance: tk-multi-workfiles2, name: File Save...}
   - {app_instance: tk-multi-publish2, name: Publish...}
-  new_file_template: alias_new_file_template_path
+  new_file_template: alias_new_file_template
   location: "@engines.tk-alias.location"
 
 # project
@@ -71,5 +71,5 @@ settings.tk-alias.project:
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.alias"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
-  new_file_template: alias_new_file_template_path
+  new_file_template: alias_new_file_template
   location: "@engines.tk-alias.location"


### PR DESCRIPTION
@barbara-darkshot @rob-aitchison 

I've defined the setting in the Alias engine, since this is only applies to Alias for now -- not sure if it is better to put it in the tk-multi-workfiles2 app instead?

The config setting value (e.g. data/templates/new_file/.../.wire) is relative to the tk-alias engine hooks/tk-multi-workfiles2 directory. I've added a `data` folder at the same level of the `basic` directory, to store the template Alias files -- let me know if you guys have any better suggestions on where to store the template files and/or how to store/retrieve the path to those files.

For now, Sebastien has only given template file for Modeling step - Exterior assets. We can add more as they come.

Here's the related tk-alias PR to go with this one:
https://github.com/shotgunsoftware/tk-alias/pull/68