### PR TITLE
Update tk-framework-desktopclient

### DIFF
--- a/env/includes/frameworks.yml
+++ b/env/includes/frameworks.yml
@@ -60,9 +60,9 @@ frameworks:
       version: v1.1.0
       type: app_store
       name: tk-framework-widget
-  tk-framework-desktopclient_v0.x.x:
+  tk-framework-desktopclient_v1.x.x:
     location:
-      version: v0.2.0
+      version: v1.0.0
       type: app_store
       name: tk-framework-desktopclient
   tk-framework-lmv_v0.x.x:


### PR DESCRIPTION
For some reason, the automatic version bump didn't work. Might be because of the major version bump?