### PR TITLE
[SHOT-4066] Remove hook for tk-multi-snapshot for tk-alias engine

### DIFF
--- a/env/includes/settings/tk-multi-snapshot.yml
+++ b/env/includes/settings/tk-multi-snapshot.yml
@@ -144,14 +144,3 @@ settings.tk-multi-snapshot.motionbuilder.shot_step:
   template_snapshot: mobu_shot_snapshot
   template_work: mobu_shot_work
   location: "@apps.tk-multi-snapshot.location"
-
-################################################################################
-
-# ---- VRED
-
-# asset step
-settings.tk-multi-snapshot.vred.asset_step:
-  template_snapshot: vred_asset_snapshot
-  template_work: vred_asset_work
-  hook_scene_operation: "{engine}/tk-multi-snapshot/basic/scene_operation.py"
-  location: "@apps.tk-multi-snapshot.location"

--- a/env/includes/settings/tk-multi-snapshot.yml
+++ b/env/includes/settings/tk-multi-snapshot.yml
@@ -147,17 +147,6 @@ settings.tk-multi-snapshot.motionbuilder.shot_step:
 
 ################################################################################
 
-# ---- Alias
-
-# asset step
-settings.tk-multi-snapshot.alias.asset_step:
-  template_snapshot: alias_asset_snapshot
-  template_work: alias_asset_work
-  hook_scene_operation: "{engine}/tk-multi-snapshot/basic/scene_operation.py"
-  location: "@apps.tk-multi-snapshot.location"
-
-################################################################################
-
 # ---- VRED
 
 # asset step


### PR DESCRIPTION
- Remove the tk-multi-snapshot App hook for tk-alias Engine now that tk-multi-snapshot no longer ships with Alias