### PR TITLE
SG-27405 Add Photoshop PNG And JPG Publish to Configs

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -254,6 +254,11 @@ paths:
         definition: '@shot_root/publish/photoshop'
     photoshop_shot_publish:
         definition: '@shot_root/publish/photoshop/{name}.v{version}.psd'
+    # The location of the published images
+    photoshop_shot_png_publish:
+        definition: '@shot_root/publish/photoshop/{name}.v{version}.png'
+    photoshop_shot_jpg_publish:
+        definition: '@shot_root/publish/photoshop/{name}.v{version}.jpg'
 
     #
     # After Effects
@@ -455,7 +460,11 @@ paths:
         definition: '@asset_root/publish/photoshop'
     photoshop_asset_publish:
         definition: '@asset_root/publish/photoshop/{name}.v{version}.psd'
-
+    # The location of the published images
+    photoshop_asset_png_publish:
+        definition: '@asset_root/publish/photoshop/{name}.v{version}.png'
+    photoshop_asset_jpg_publish:
+        definition: '@asset_root/publish/photoshop/{name}.v{version}.jpg'
     #
     # after effects
     #

--- a/env/includes/settings/tk-multi-publish2.yml
+++ b/env/includes/settings/tk-multi-publish2.yml
@@ -324,6 +324,21 @@ settings.tk-multi-publish2.photoshop.asset_step:
   - name: Upload for review
     hook: "{engine}/tk-multi-publish2/basic/upload_version.py"
     settings: {}
+  - name: Publish PNG to Shotgun
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_image.py"
+    settings:
+      Publish Template: photoshop_asset_png_publish
+      Export Settings:
+        format: PNG
+        PNG8: False
+        quality: 100
+  - name: Publish JPEG to Shotgun
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_image.py"
+    settings:
+      Publish Template: photoshop_asset_jpg_publish
+      Export Settings:
+        format: JPEG
+        quality: 100
   help_url: *help_url
   location: "@apps.tk-multi-publish2.location"
 
@@ -349,6 +364,21 @@ settings.tk-multi-publish2.photoshop.shot_step:
   - name: Upload for review
     hook: "{engine}/tk-multi-publish2/basic/upload_version.py"
     settings: {}
+  - name: Publish PNG to Shotgun
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_image.py"
+    settings:
+      Publish Template: photoshop_shot_png_publish
+      Export Settings:
+        format: PNG
+        PNG8: False
+        quality: 100
+  - name: Publish JPEG to Shotgun
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_image.py"
+    settings:
+      Publish Template: photoshop_shot_jpg_publish
+      Export Settings:
+        format: JPEG
+        quality: 100
   help_url: *help_url
   location: "@apps.tk-multi-publish2.location"
 


### PR DESCRIPTION
Add new publish plugin to photoshop engine in order to export PSD as Add new publish plugin to photoshop engine in order to export PSD as images and publish them to ShotGrid.