### PR TITLE
SHOT-4259: Alias/VRED run Workfiles2 at start up via config

### DIFF
--- a/env/includes/settings/tk-alias.yml
+++ b/env/includes/settings/tk-alias.yml
@@ -70,4 +70,6 @@ settings.tk-alias.project:
     tk-multi-data-validation: "@settings.tk-multi-data-validation.alias"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
+  run_at_startup:
+  - { app_instance: tk-multi-workfiles2, name: 'File Open...' }
   location: "@engines.tk-alias.location"

--- a/env/includes/settings/tk-vred.yml
+++ b/env/includes/settings/tk-vred.yml
@@ -89,6 +89,7 @@ settings.tk-vred.project:
   - {app_instance: tk-multi-workfiles2, name: File Open...}
   run_at_startup:
   - { app_instance: tk-multi-shotgunpanel, name: '' }
+  - { app_instance: tk-multi-workfiles2, name: 'File Open...' }
   - { app_instance: tk-multi-pythonconsole, name: 'ShotGrid Python Console...' }
   - { app_instance: tk-multi-data-validation, name: 'Data Validation...' }
   docked_apps:


### PR DESCRIPTION
Alias and VRED removed from Workfiles2 as supported engine to run at startup. We will do this via the config instead.