### PR TITLE
SG-38376 Add support for Nuke 16

### DIFF
--- a/env/includes/software_paths.yml
+++ b/env/includes/software_paths.yml
@@ -23,9 +23,9 @@ path.windows.mari: C:\Program Files\Mari7.0v2\Bundle\bin\Mari7.0v2.exe
 path.windows.motionbuilder: C:\Program Files\Autodesk\MotionBuilder 2026\bin\x64\motionbuilder.exe
 
 # Hiero
-path.linux.hiero: "Nuke12.1"
-path.mac.hiero: "/Applications/Nuke12.1v4/Hiero12.1v4.app"
-path.windows.hiero: E:\Program Files\Nuke13.2v2\Nuke13.2.exe
+path.linux.hiero: "Nuke16.0"
+path.mac.hiero: "/Applications/Nuke16.0v1/Hiero16.0v1.app"
+path.windows.hiero: C:\Program Files\Nuke16.0v1\Nuke16.0.exe
 
 # RV
 path.linux.rv: "rv"

--- a/env/includes/software_paths.yml
+++ b/env/includes/software_paths.yml
@@ -23,7 +23,7 @@ path.windows.mari: C:\Program Files\Mari7.0v2\Bundle\bin\Mari7.0v2.exe
 path.windows.motionbuilder: C:\Program Files\Autodesk\MotionBuilder 2026\bin\x64\motionbuilder.exe
 
 # Hiero
-path.linux.hiero: "Nuke16.0"
+path.linux.hiero: "/usr/local/Nuke16.0v1/Nuke16.0"
 path.mac.hiero: "/Applications/Nuke16.0v1/Hiero16.0v1.app"
 path.windows.hiero: C:\Program Files\Nuke16.0v1\Nuke16.0.exe
 


### PR DESCRIPTION
Update Hiero path to 16.0v1.

Also change the Linux path to an absolute path because the Nuke installation folders are not in `$PATH`.

Related to shotgunsoftware/tk-nuke#115 and shotgunsoftware/tk-hiero-export#62