### PR TITLE
SG-42791 Update default path for nuke/hiero

### DIFF
--- a/env/includes/software_paths.yml
+++ b/env/includes/software_paths.yml
@@ -22,9 +22,9 @@ path.windows.mari: C:\Program Files\Mari7.0v2\Bundle\bin\Mari7.0v2.exe
 path.windows.motionbuilder: C:\Program Files\Autodesk\MotionBuilder 2026\bin\x64\motionbuilder.exe
 
 # Hiero
-path.linux.hiero: "/usr/local/Nuke16.0v1/Nuke16.0"
-path.mac.hiero: "/Applications/Nuke16.0v1/Hiero16.0v1.app"
-path.windows.hiero: C:\Program Files\Nuke16.0v1\Nuke16.0.exe
+path.linux.hiero: "/usr/local/Nuke17.0v1/Nuke17.0"
+path.mac.hiero: "/Applications/Nuke17.0v1/Hiero17.0v1.app"
+path.windows.hiero: C:\Program Files\Nuke17.0v1\Nuke17.0.exe
 
 # RV
 path.linux.rv: "rv"


### PR DESCRIPTION
This pull request updates the Hiero software paths in the `env/includes/software_paths.yml` configuration file to point to version 17.0 instead of version 16.0. This ensures that all environments (Linux, Mac, Windows) will now use the latest Hiero version.

Updated Hiero software paths:

* Updated `path.linux.hiero` to use `/usr/local/Nuke17.0v1/Nuke17.0`
* Updated `path.mac.hiero` to use `/Applications/Nuke17.0v1/Hiero17.0v1.app`
* Updated `path.windows.hiero` to use `C:\Program Files\Nuke17.0v1\Nuke17.0.exe`