### PR TITLE
SG-43811 Add new Nuke publish hooks for handling FlowWrite

### DIFF
--- a/env/includes/settings/tk-multi-publish2.yml
+++ b/env/includes/settings/tk-multi-publish2.yml
@@ -217,7 +217,7 @@ settings.tk-multi-publish2.nuke.asset_step:
       Work Template: nuke_asset_work
   publish_plugins:
   - name: Publish to Flow Production Tracking
-    hook: "{self}/publish_file.py"
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_publish_file.py"
     settings: {}
   - name: Upload for review
     hook: "{self}/upload_version.py"
@@ -229,6 +229,9 @@ settings.tk-multi-publish2.nuke.asset_step:
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_publish_script.py"
     settings:
         Publish Template: nuke_asset_publish
+  - name: Publish FlowWrite Renders to Flow AM
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_flow_write_publish_script.py"
+    settings: {}
   - name: Submit for Review
     hook: "{engine}/tk-multi-publish2/basic/submit_for_review.py"
     settings: {}
@@ -242,7 +245,7 @@ settings.tk-multi-publish2.nuke.shot_step:
       Work Template: nuke_shot_work
   publish_plugins:
   - name: Publish to Flow Production Tracking
-    hook: "{self}/publish_file.py"
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_publish_file.py"
     settings: {}
   - name: Upload for review
     hook: "{self}/upload_version.py"
@@ -254,6 +257,9 @@ settings.tk-multi-publish2.nuke.shot_step:
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_publish_script.py"
     settings:
         Publish Template: nuke_shot_publish
+  - name: Publish FlowWrite Renders to Flow AM
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/nuke_flow_write_publish_script.py"
+    settings: {}
   - name: Submit for Review
     hook: "{engine}/tk-multi-publish2/basic/submit_for_review.py"
     settings: {}


### PR DESCRIPTION
DO NOT MERGE

This PR adds new Nuke publish hooks for handling renders from new FlowWrite node.
Since this requires the latest version of Nuke, do not merge until Flow integration has been formally released.