### PR TITLE
SG-43958 Expose loader in desktop with flowam actions

### DIFF
--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -15,3 +15,8 @@ location:
   type: app_store
   name: tk-core
   version: v0.23.9
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-core.git
+  version: 0df22bc70fd8bc15b1d26a2ea82a87e8220b9e60

--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -15,7 +15,7 @@ location:
   type: app_store
   name: tk-core
   version: v0.23.9
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-core.git

--- a/core/core_api.yml
+++ b/core/core_api.yml
@@ -14,9 +14,4 @@
 location:
   type: app_store
   name: tk-core
-  version: v0.23.9
-  # QA: Use latest branch until it is released
-  type: git_branch
-  branch: master
-  path: git@github.com:shotgunsoftware/tk-core.git
-  version: 0df22bc70fd8bc15b1d26a2ea82a87e8220b9e60
+  version: v0.24.1

--- a/env/includes/app_locations.yml
+++ b/env/includes/app_locations.yml
@@ -32,6 +32,11 @@ apps.tk-multi-breakdown2.location:
   type: app_store
   name: tk-multi-breakdown2
   version: v0.4.5
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: main
+  path: git@github.com:shotgunsoftware/tk-multi-breakdown2.git
+  version: cd2ca679891979d4de440c2c78ccd33766111f84
 apps.tk-multi-data-validation.location:
   type: app_store
   name: tk-multi-data-validation
@@ -48,10 +53,20 @@ apps.tk-multi-loader2.location:
   type: app_store
   name: tk-multi-loader2
   version: v1.25.6
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-multi-loader2.git
+  version: ccae09491a39dc5d58e3733cbfa191baf1babb64
 apps.tk-multi-publish2.location:
   type: app_store
   name: tk-multi-publish2
   version: v2.11.0
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-multi-publish2.git
+  version: 2c4730b79ed201a47a5db248ca05c405a3ce15d3
 apps.tk-multi-pythonconsole.location:
   type: app_store
   name: tk-multi-pythonconsole

--- a/env/includes/app_locations.yml
+++ b/env/includes/app_locations.yml
@@ -34,7 +34,7 @@ apps.tk-multi-breakdown2.location:
   version: v0.4.5
   # REMOVEME: Get latest branch from it is released
   type: git_branch
-  branch: main
+  branch: master
   path: git@github.com:shotgunsoftware/tk-multi-breakdown2.git
   version: cd2ca679891979d4de440c2c78ccd33766111f84
 apps.tk-multi-data-validation.location:

--- a/env/includes/app_locations.yml
+++ b/env/includes/app_locations.yml
@@ -57,7 +57,7 @@ apps.tk-multi-loader2.location:
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-loader2.git
-  version: ccae09491a39dc5d58e3733cbfa191baf1babb64
+  version: 653474e14d81a3636a0c853c8ffd0246bd935fcf
 apps.tk-multi-publish2.location:
   type: app_store
   name: tk-multi-publish2
@@ -66,7 +66,7 @@ apps.tk-multi-publish2.location:
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-publish2.git
-  version: 2c4730b79ed201a47a5db248ca05c405a3ce15d3
+  version: f2317513ac756b47e4f855663567875a58a9528c
 apps.tk-multi-pythonconsole.location:
   type: app_store
   name: tk-multi-pythonconsole

--- a/env/includes/app_locations.yml
+++ b/env/includes/app_locations.yml
@@ -32,7 +32,7 @@ apps.tk-multi-breakdown2.location:
   type: app_store
   name: tk-multi-breakdown2
   version: v0.4.5
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-breakdown2.git
@@ -53,7 +53,7 @@ apps.tk-multi-loader2.location:
   type: app_store
   name: tk-multi-loader2
   version: v1.25.6
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-loader2.git
@@ -62,7 +62,7 @@ apps.tk-multi-publish2.location:
   type: app_store
   name: tk-multi-publish2
   version: v2.11.0
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-multi-publish2.git

--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -49,7 +49,7 @@ engines.tk-houdini.location:
   # REMOVEME: Get latest branch from it is released
   type: git_branch
   branch: master
-  path: git@github.com:shotgunsoftware/tk-core.git
+  path: git@github.com:shotgunsoftware/tk-houdini.git
   version: 13a898c4b32289f0f11be5ddf54d141719384c21
 engines.tk-mari.location:
   type: app_store
@@ -62,7 +62,7 @@ engines.tk-maya.location:
   # REMOVEME: Get latest branch from it is released
   type: git_branch
   branch: master
-  path: git@github.com:shotgunsoftware/tk-core.git
+  path: git@github.com:shotgunsoftware/tk-maya.git
   version: 6b279ec303fd5e76699b6d206e34198872fd5280
 engines.tk-motionbuilder.location:
   type: app_store
@@ -75,7 +75,7 @@ engines.tk-nuke.location:
   # REMOVEME: Get latest branch from it is released
   type: git_branch
   branch: master
-  path: git@github.com:shotgunsoftware/tk-core.git
+  path: git@github.com:shotgunsoftware/tk-nuke.git
   version: 02808561cd29466fa6a3aca0e8249b99868e2a47
 engines.tk-photoshopcc.location:
   type: app_store

--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -29,7 +29,7 @@ engines.tk-desktop.location:
   type: app_store
   name: tk-desktop
   version: v2.8.6
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-desktop.git
@@ -46,7 +46,7 @@ engines.tk-houdini.location:
   type: app_store
   name: tk-houdini
   version: v1.9.12
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-houdini.git
@@ -59,7 +59,7 @@ engines.tk-maya.location:
   type: app_store
   name: tk-maya
   version: v0.13.11
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-maya.git
@@ -72,7 +72,7 @@ engines.tk-nuke.location:
   type: app_store
   name: tk-nuke
   version: v0.16.4
-  # REMOVEME: Get latest branch from it is released
+  # QA: Use latest branch until it is released
   type: git_branch
   branch: master
   path: git@github.com:shotgunsoftware/tk-nuke.git

--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -29,6 +29,11 @@ engines.tk-desktop.location:
   type: app_store
   name: tk-desktop
   version: v2.8.6
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-desktop.git
+  version: c528bccf01fc1c35e1f676f70bf532a42273b1b6
 engines.tk-desktop2.location:
   type: app_store
   name: tk-desktop2
@@ -41,6 +46,11 @@ engines.tk-houdini.location:
   type: app_store
   name: tk-houdini
   version: v1.9.12
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-core.git
+  version: 13a898c4b32289f0f11be5ddf54d141719384c21
 engines.tk-mari.location:
   type: app_store
   name: tk-mari
@@ -49,6 +59,11 @@ engines.tk-maya.location:
   type: app_store
   name: tk-maya
   version: v0.13.11
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-core.git
+  version: 6b279ec303fd5e76699b6d206e34198872fd5280
 engines.tk-motionbuilder.location:
   type: app_store
   name: tk-motionbuilder
@@ -57,6 +72,11 @@ engines.tk-nuke.location:
   type: app_store
   name: tk-nuke
   version: v0.16.4
+  # REMOVEME: Get latest branch from it is released
+  type: git_branch
+  branch: master
+  path: git@github.com:shotgunsoftware/tk-core.git
+  version: 02808561cd29466fa6a3aca0e8249b99868e2a47
 engines.tk-photoshopcc.location:
   type: app_store
   name: tk-photoshopcc

--- a/env/includes/settings/tk-desktop.yml
+++ b/env/includes/settings/tk-desktop.yml
@@ -17,6 +17,7 @@ includes:
 - ./tk-multi-launchapp.yml
 - ./tk-multi-publish2.yml
 - ./tk-multi-screeningroom.yml
+- ./tk-multi-loader2.yml
 
 ################################################################################
 
@@ -39,6 +40,7 @@ settings.tk-desktop.project:
     tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-multi-loader2: "@settings.tk-multi-loader2.standalone"
   groups:
   - matches:
     - "*Fla*"

--- a/env/includes/settings/tk-houdini.yml
+++ b/env/includes/settings/tk-houdini.yml
@@ -70,6 +70,7 @@ settings.tk-houdini.project:
       location: "@apps.tk-multi-about.location"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
+    tk-multi-loader2: "@settings.tk-multi-loader2.houdini"  # Display loader on project context
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.houdini"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}

--- a/env/includes/settings/tk-maya.yml
+++ b/env/includes/settings/tk-maya.yml
@@ -72,6 +72,7 @@ settings.tk-maya.project:
       location: "@apps.tk-multi-about.location"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
+    tk-multi-loader2: "@settings.tk-multi-loader2.maya"  # Display loader on project context
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2.launch_at_startup"
   menu_favourites:
   - {app_instance: tk-multi-workfiles2, name: File Open...}

--- a/env/includes/settings/tk-multi-loader2.yml
+++ b/env/includes/settings/tk-multi-loader2.yml
@@ -422,15 +422,6 @@ settings.tk-multi-loader2.vred:
 
 # desktop standalone Flow AM
 settings.tk-multi-loader2.standalone:
-  action_mappings:
-    # DCC file types can only be published within DCC to avoid data corruption
-    Maya Workfile: [download, reference_copy_link]
-    Nuke Workfile: [download, reference_copy_link]
-    Houdini Workfile: [download, reference_copy_link]
-    All: [download, publish, reference_copy_link]
-  entity_mappings:
-    Task: [create_generic_asset]
-    Project: [create_generic_asset]
   entities:
   - caption: Current Project
     type: Query

--- a/env/includes/settings/tk-multi-loader2.yml
+++ b/env/includes/settings/tk-multi-loader2.yml
@@ -71,6 +71,10 @@ settings.tk-multi-loader2.houdini:
     Rendered Image: [file_cop]
     Texture: [file_cop]
   entities:
+  - caption: Current Project
+    type: Hierarchy
+    root: "{context.project}"
+    publish_filters: []
   - caption: Assets
     entity_type: Asset
     filters:
@@ -131,6 +135,10 @@ settings.tk-multi-loader2.maya:
     Rendered Image: [texture_node, image_plane]
     Texture: [texture_node, image_plane]
   entities:
+  - caption: Current Project
+    type: Hierarchy
+    root: "{context.project}"
+    publish_filters: []
   - caption: Assets
     entity_type: Asset
     filters:
@@ -168,6 +176,10 @@ settings.tk-multi-loader2.nuke:
     Rendered Image: [read_node]
     Texture: [read_node]
   entities:
+  - caption: Current Project
+    type: Hierarchy
+    root: "{context.project}"
+    publish_filters: []
   - caption: Assets
     entity_type: Asset
     filters:

--- a/env/includes/settings/tk-multi-loader2.yml
+++ b/env/includes/settings/tk-multi-loader2.yml
@@ -419,3 +419,32 @@ settings.tk-multi-loader2.vred:
   actions_hook: "{engine}/tk-multi-loader2/basic/scene_actions.py"
   publish_filters: [["sg_status_list", "is_not", null]]
   location: "@apps.tk-multi-loader2.location"
+
+# desktop standalone Flow AM
+settings.tk-multi-loader2.standalone:
+  action_mappings:
+    # DCC file types can only be published within DCC to avoid data corruption
+    Maya Workfile: [download, reference_copy_link]
+    Nuke Workfile: [download, reference_copy_link]
+    Houdini Workfile: [download, reference_copy_link]
+    All: [download, publish, reference_copy_link]
+  entity_mappings:
+    Task: [create_generic_asset]
+    Project: [create_generic_asset]
+  entities:
+  - caption: Current Project
+    type: Query
+    entity_type: Project
+    publish_filters: []
+    filters:
+    - ["id", "is", "{context.project.id}"]
+    hierarchy: [name]
+  - caption: My Tasks
+    type: Query
+    entity_type: Task
+    publish_filters: []
+    filters:
+    - [task_assignees, is, "{context.user}"]
+    - ["project", "is", "{context.project}"]
+    hierarchy: [entity, content]
+  location: "@apps.tk-multi-loader2.location"

--- a/env/includes/settings/tk-multi-publish2.yml
+++ b/env/includes/settings/tk-multi-publish2.yml
@@ -108,6 +108,9 @@ settings.tk-multi-publish2.houdini.asset_step:
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
     settings:
         Publish Template: houdini_asset_publish
+  - name: Publish Alembic Derivative
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py:{self}/flowam/publish_alembic_derivative.py"
+    settings: {}
   help_url: *help_url
   location: "@apps.tk-multi-publish2.location"
 
@@ -130,6 +133,9 @@ settings.tk-multi-publish2.houdini.shot_step:
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
     settings:
         Publish Template: houdini_shot_publish
+  - name: Publish Alembic Derivative
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py:{self}/flowam/publish_alembic_derivative.py"
+    settings: {}
   help_url: *help_url
   location: "@apps.tk-multi-publish2.location"
 
@@ -181,6 +187,9 @@ settings.tk-multi-publish2.maya.asset_step:
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session_geometry.py"
     settings:
         Publish Template: asset_alembic_cache
+  - name: Publish Alembic Derivative
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py:{self}/flowam/publish_alembic_derivative.py"
+    settings: {}
   help_url: *help_url
   location: "@apps.tk-multi-publish2.location"
 
@@ -203,6 +212,9 @@ settings.tk-multi-publish2.maya.shot_step:
     hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py"
     settings:
         Publish Template: maya_shot_publish
+  - name: Publish Alembic Derivative
+    hook: "{self}/publish_file.py:{engine}/tk-multi-publish2/basic/publish_session.py:{self}/flowam/publish_alembic_derivative.py"
+    settings: {}
   help_url: *help_url
   location: "@apps.tk-multi-publish2.location"
 

--- a/env/includes/settings/tk-nuke.yml
+++ b/env/includes/settings/tk-nuke.yml
@@ -126,6 +126,7 @@ settings.tk-nuke.project:
       location: "@apps.tk-multi-about.location"
     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
     tk-multi-shotgunpanel: "@settings.tk-multi-shotgunpanel"
+    tk-multi-loader2: "@settings.tk-multi-loader2.nuke"  # Display loader on project context
     tk-multi-workfiles2: "@settings.tk-multi-workfiles2"
     tk-nuke-quickreview:
       location: "@apps.tk-nuke-quickreview.location"


### PR DESCRIPTION
Branch for feature testing

## Differences from production release

1. Unreleased descriptors for core, engines, and apps
2. Show the loader in the FPT desktop the same way as the publisher is displayed.
3. Display the loader on DCCs (maya, houdini, nuke) on start up. No need to create a new workfile (because that will change the context to asset step losing the flow project id).
4. Add "Current Project" tab to the treeview in the DCC loader, so we can trigger "Create new template".
5. Register the FlowAM alembic derivative publish plugin in the Houdini and Maya publish_plugins lists (asset_step and shot_step)
